### PR TITLE
Option to whitelist script source, if CSP is enabled

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -21,4 +21,4 @@ subdomain_tracking:
 extend_content_security_policy:
   type: list
   default: ''
-  description: Host URL with http:// or https:// to whitelist script source (format: "script_src: https://myHost.URL/piwik.js")
+  description: 'Host URL with http:// or https:// to whitelist script source (format: "script_src: https://myHost.URL/piwik.js")'

--- a/settings.yml
+++ b/settings.yml
@@ -18,3 +18,7 @@ subdomain_tracking:
   type: bool
   default: false
   description: Track visitors across main domain & subdomains, assuming discourse is on a subdomain.
+extend_content_security_policy:
+  type: list
+  default: ''
+  description: Host URL with http:// or https:// to whitelist script source (format: "script_src: https://myHost.URL/piwik.js")


### PR DESCRIPTION
This is needed to allow our Matomo-Script to be loaded from an external source. This can also be done inside the Discourse Settings/Security _"content security policy script src"_, but this option keeps all needed settings at one point.